### PR TITLE
fix: parser take enums as keys for ngx-translate #61

### DIFF
--- a/src/core/utils/keys.ts
+++ b/src/core/utils/keys.ts
@@ -15,7 +15,7 @@ class KeysUtils {
     public static findKeysList(keys: string[]): RegExp {
         const keysFromDirectiveInsideTag: string = `(?<=<[\\s*\\w*\\s*]*translate[\\s*\\w*\\s*]*[^>]*>\\s*)([a-zA-Z0-9_.]*)(?=\\s*<\\s*\\/.*\\s*>)`;
         const keysFromDirectiveInView: string = `(?<=translate=["']{1,2}|\\[translate\\]=["']{1,2})([A-Za-z0-9_.]+)(?=["']{1,2})`;
-        const keysFromPipeInView: string = `(?<=['"])([a-zA-Z0-9_.]*)(?=['"]\\s?\\|\\s?translate|['"](\\s*\\|\\s*\\w*)*translate)`;
+        const keysFromPipeInView: string = `(?<=['"])([a-zA-Z0-9_\\-.]*)(?=['"]\\s?\\|\\s?translate|['"](\\s*\\|\\s*\\w*)*translate)`;
         const keysListRegExp: string = keys.map((key: string) => {
             const regExpForSingleKey: string = `(?<=[^\\w.-])${key.replace('.', '\\.')}(?=[^\\w.-])`;
             return regExpForSingleKey;

--- a/test/integration/inputs/views/pipe.keys.html
+++ b/test/integration/inputs/views/pipe.keys.html
@@ -5,3 +5,8 @@
     {{ 'STRING.KEY_FROM_PIPE_VIEW.MISPRINT_IN_ONE_LOCALES' | translate }}
     {{ 'OBJECT.KEY_FROM_PIPE_VIEW.EXIST_IN_ALL_LOCALES' | translate }}
 </div>
+<div>
+    <!-- BUG 61 -->
+    <h1 *ngIf="creatorState === CreatorState.NEW">{{'carousel.details.title-new' | translate}}</h1>
+    <!-- END BUG 61 -->
+</div>

--- a/test/integration/results/custom.config.ts
+++ b/test/integration/results/custom.config.ts
@@ -70,6 +70,16 @@ const assertCustomConfig: ResultErrorModel[] = [
             'EN-us.json'
         ]
     ),
+    // BUG 61
+    new ResultErrorModel(
+        'carousel.details.title-new',
+        ErrorFlow.views, ErrorTypes.warning,
+        getAbsolutePath(projectFolder, 'pipe.keys.html'),
+        [
+            'EN-eu.json',
+            'EN-us.json'
+        ]
+    ),
 ];
 
 export { assertCustomConfig };

--- a/test/integration/results/default.full.ts
+++ b/test/integration/results/default.full.ts
@@ -83,6 +83,16 @@ const assertDefaultModel: ResultErrorModel[]= [
             'EN-us.json'
         ]
     ),
+    // BUG 61
+    new ResultErrorModel(
+        'carousel.details.title-new',
+        ErrorFlow.views, ErrorTypes.error,
+        getAbsolutePath(projectFolder, 'pipe.keys.html'),
+        [
+            'EN-eu.json',
+            'EN-us.json'
+        ]
+    ),
     new ResultErrorModel(
         'STRING.KEY_FROM_PIPE_VIEW.MISPRINT_IN_ONE_LOCALES',
         ErrorFlow.misprint, ErrorTypes.warning,


### PR DESCRIPTION
Part of #61 