### PR TITLE
fix: parser take enums as keys for ngx-translate

### DIFF
--- a/src/core/utils/keys.ts
+++ b/src/core/utils/keys.ts
@@ -26,7 +26,7 @@ class KeysUtils {
             keysFromDirectiveInView,
             keysFromDirectiveInsideTag,
         ];
-        return new RegExp(resultKeysRegExp.join('|'), 'gmi');
+        return new RegExp(resultKeysRegExp.join('|'), 'gm');
     }
 }
 

--- a/test/integration/inputs/locales/EN-eu.json
+++ b/test/integration/inputs/locales/EN-eu.json
@@ -24,5 +24,6 @@
         "KEY_FROM_ENUM": {
             "EXIST_IN_ALL_LOCALES": "Key from enum"
         }
-    }
+    },
+    "creatorState.NEW": "BUG 61"
 }

--- a/test/integration/inputs/views/pipe.keys.html
+++ b/test/integration/inputs/views/pipe.keys.html
@@ -8,5 +8,6 @@
 <div>
     <!-- BUG 61 -->
     <h1 *ngIf="creatorState === CreatorState.NEW">{{'carousel.details.title-new' | translate}}</h1>
+    <h1 *ngIf="creatorState === CreatorState.NEW">{{'creatorState.NEW' | translate}}</h1>
     <!-- END BUG 61 -->
 </div>

--- a/test/integration/results/custom.config.ts
+++ b/test/integration/results/custom.config.ts
@@ -80,6 +80,15 @@ const assertCustomConfig: ResultErrorModel[] = [
             'EN-us.json'
         ]
     ),
+    new ResultErrorModel(
+        'creatorState.NEW',
+        ErrorFlow.views, ErrorTypes.warning,
+        getAbsolutePath(projectFolder, 'pipe.keys.html'),
+        [
+            'EN-us.json',
+        ]
+    ),
+    // END BUG 61
 ];
 
 export { assertCustomConfig };

--- a/test/integration/results/default.full.ts
+++ b/test/integration/results/default.full.ts
@@ -94,6 +94,15 @@ const assertDefaultModel: ResultErrorModel[]= [
         ]
     ),
     new ResultErrorModel(
+        'creatorState.NEW',
+        ErrorFlow.views, ErrorTypes.error,
+        getAbsolutePath(projectFolder, 'pipe.keys.html'),
+        [
+            'EN-us.json'
+        ]
+    ),
+    // END BUG 61
+    new ResultErrorModel(
         'STRING.KEY_FROM_PIPE_VIEW.MISPRINT_IN_ONE_LOCALES',
         ErrorFlow.misprint, ErrorTypes.warning,
         getAbsolutePath(projectFolder, 'pipe.keys.html'),


### PR DESCRIPTION
Close #61
