### PR TITLE
feat: add Regular Expression support for ignoredKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ which should exist in all languages files.
 ```bash
 npm install ngx-translate-lint -g
 
-BETA: 
+BETA:
 
-npm install ngx-translate-lint @angular/core @angular/compiler @angular/compiler-cli -g 
+npm install ngx-translate-lint @angular/core @angular/compiler @angular/compiler-cli -g
 ```
 
 ### GitHub
@@ -99,7 +99,7 @@ Examples:
 > NOTE: For `project` and `languages` options need to include file types like on the example.
 > WARNING!: `BETA` flag working only with angular 11 and higher!
 
-Default Config is: 
+Default Config is:
 ```json
 {
     "rules": {
@@ -108,7 +108,7 @@ Default Config is:
         "misprint": "warning",
         "maxWarning": "0",
         "misprintCoefficient": "0.9",
-        "ignoredKeys": [],
+        "ignoredKeys": [ "IGNORED.KEY.(.*)" ], // can be string or RegExp
         "ignoredMisprintKeys": [],
         "ast": {
           "isNgsTranslateImported": "error"
@@ -142,7 +142,7 @@ const ruleConfig: IRulesConfig = {
         misprint: ErrorTypes.warning,
         maxWarning: 0,
         misprintCoefficient: 0.9,
-        ignoredKeys: [ 'EXAMPLE.KEY' ],
+        ignoredKeys: [ 'EXAMPLE.KEY', 'IGNORED.KEY.(.*)' ], // can be string or RegExp
         ignoredMisprintKeys: []
 };
 
@@ -152,7 +152,7 @@ const languages: LanguagesModel[] = ngxTranslateLint.getLanguages()  // Get Lang
 
 ```
 
-#### NOTE! 
+#### NOTE!
 If you have error `Can't resolve 'fs' in ...`. Please add next setting to you project:
  - webpack.js: (`angular.webpack.json`)
 ```javascript
@@ -161,7 +161,7 @@ config.externals = {
     "fs": 'require("fs")',
     "path": 'require("path")'
 };
-``` 
+```
  - tsconfig.json
  ```json
 {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -72,7 +72,7 @@ class NgxTranslateLint {
         if(this.rules.ignoredKeys?.length !== 0) {
             errors = errors.reduce<ResultErrorModel[]>((acum, errorKey) => {
                 const errorKeyValue: string = errorKey.value;
-                if (!this.rules.ignoredKeys.includes(errorKeyValue)) {
+                if (!this.rules.ignoredKeys.some(ignoredKey => new RegExp(ignoredKey, "i").test(errorKeyValue))) {
                     const correctError: ResultErrorModel = new ResultErrorModel(
                         errorKey.value,
                         errorKey.errorFlow,


### PR DESCRIPTION
---
name: Pull request
about: Request to change the source code

---

# Description

Add Regular Expression functionality for the "ignoredKeys" rule.
This allows a more precise specification of ignored keys (like ignoring all childs of a parent)

**Example Config**
```
{
    "rules": {
        "keysOnViews": "error",
        "zombieKeys": "warning",
        "misprint": "warning",
        "maxWarning": "0",
        "misprintCoefficient": "0.9",
        "ignoredKeys": ["IGNORED.KEY.(.*)"],
        "ignoredMisprintKeys": [],
        "ast": {
          "isNgsTranslateImported": "error"
        }
    },
    "tsconfig": "./",
    "project": "./src/app/**/*.{html,ts}",
    "languages": "./src/assets/i18n/*.json"
}
```

## Issues Resolved

Closes #111

## Check List

- [x] The commit message is formatted
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] All user-facing changes accompanied by the correspondent documentation
- [x] All tests pass
- [x] PR include resolved issues
- [x] PR include description
