### PR TITLE
docs(README): add "customRegExpToFindKeys" attribute to "TypeScript" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ const ruleConfig: IRulesConfig = {
         maxWarning: 0,
         misprintCoefficient: 0.9,
         ignoredKeys: [ 'EXAMPLE.KEY', 'IGNORED.KEY.(.*)' ], // can be string or RegExp
-        ignoredMisprintKeys: []
+        ignoredMisprintKeys: [],
+        customRegExpToFindKeys: []
 };
 
 const ngxTranslateLint = new NgxTranslateLint(viewsPath, languagesPath, ignoredLanguagesPath, ruleConfig)


### PR DESCRIPTION
# Description

Add missing "customRegExpToFindKeys" attribute to README "TypeScript" config example

## Check List

- [x] The commit message is formatted
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] All user-facing changes accompanied by the correspondent documentation
- [x] All tests pass
- [x] PR include resolved issues
- [x] PR include description
