### PR TITLE
Remove useless dependency on ngast

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
         "fs": "0.0.1-security",
         "glob": "^7.1.4",
         "lodash": "^4.17.20",
-        "ngast": "^0.6.2",
         "path": "^0.12.7",
         "rxjs": "^6.5.4",
         "string-similarity": "^4.0.1",

--- a/src/cli/dictionaries/CliOptions.ts
+++ b/src/cli/dictionaries/CliOptions.ts
@@ -1,6 +1,6 @@
 import { ArgumentTypes } from 'conventional-cli';
 
-import { OptionModel } from './../models';
+import { OptionModel } from '../models';
 import { config, ErrorTypes, ToggleRule } from './../../core';
 import { OptionsLongNames, OptionsPath, OptionsShortNames } from './../enums';
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,6 +1,5 @@
 import { flatMap } from 'lodash';
 import * as path from 'path';
-import { join } from 'path';
 import { config } from './config';
 import { ErrorTypes } from './enums';
 import { IRulesConfig } from './interface';
@@ -8,8 +7,6 @@ import { KeysUtils } from './utils';
 import { FileLanguageModel, FileViewModel, KeyModel, LanguagesModel, ResultCliModel, ResultErrorModel } from './models';
 import { AbsentViewKeysRule, MisprintRule, ZombieRule, EmptyKeysRule } from './rules';
 import { KeyModelWithLanguages, LanguagesModelWithKey, ViewModelWithKey } from './models/KeyModelWithLanguages';
-import { WorkspaceSymbols } from 'ngast';
-import { NgModuleSymbol } from 'ngast/lib/ngtsc/module.symbol';
 
 
 class NgxTranslateLint {


### PR DESCRIPTION
# Description

imports about ngast are not used in code and consequently dependency on ngast in package.json is useless.
So cleanup all references about ngast.

## Check List

- [X] The commit message is formatted
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] All user-facing changes accompanied by the correspondent documentation
- [X] All tests pass
- [ ] PR include resolved issues
- [X] PR include description
